### PR TITLE
Set client_max_body_size to 1GB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN mkdir -p /var/log/nginx /var/cache/nginx /var/run/nginx && \
 
 RUN echo "server_names_hash_bucket_size 128;" >/etc/nginx/conf.d/_server_name_hash.conf
 
+RUN echo "client_max_body_size 1g;" >/etc/nginx/conf.d/my_proxy.conf
+
 EXPOSE 80
 
 USER nginx


### PR DESCRIPTION
It helped me with a problem sending files to nextcloud on docker.
https://github.com/nextcloud/docker/issues/404